### PR TITLE
Flag name as reference can be customised.

### DIFF
--- a/flag_test.go
+++ b/flag_test.go
@@ -446,7 +446,6 @@ func TestFlagSetParse(t *testing.T) {
 	// Flags are to be known as 'options', using alt constructor
 	testParse(func() *FlagSet {
 		f := NewFlagSetWithFlagKnownAs("test", ContinueOnError, "option")
-		//f.SetAKA("option")
 		f.SetOutput(nullWriter{})
 		return f
 	}, t)


### PR DESCRIPTION
This allows projects to customize what flags are known as.
For example, Juju would like to call individual items in the flag set 'options'. This change ensures that we can create a flag set with item alias as 'option', so that all error messages coming form this package are referring to individual items as 'option' to ensure consistent user experience.

For example, 'value for flag' will become 'value for option' as well as 'invalid flag' will become 'invalid option'.

This PR also modified unit tests to ensure that the name of flag is customized as well as that the default 'flag' is used.

Related Juju bug: https://bugs.launchpad.net/juju/+bug/1637821
 